### PR TITLE
Use Beatmap Factory instead of V2 objects directly

### DIFF
--- a/Automapper.cs
+++ b/Automapper.cs
@@ -30,7 +30,7 @@ using UnityEngine.SceneManagement;
 using Automapper.Items;
 using UnityEngine;
 using Beatmap.Base;
-using Beatmap.V2;
+using Beatmap.Helper;
 
 namespace Automapper
 {
@@ -256,18 +256,14 @@ namespace Automapper
                             if (notes[index - 1].Type == 0)
                             {
                                 lastRed = notes[index - 1];
-                                lastBlue = new V2Note
-                                {
-                                    Type = 1
-                                };
+                                lastBlue = BeatmapFactory.Note();
+                                lastBlue.Type = 1;
                             }
                             else
                             {
                                 lastBlue = notes[index - 1];
-                                lastRed = new V2Note
-                                {
-                                    Type = 0
-                                };
+                                lastRed = BeatmapFactory.Note();
+                                lastRed.Type= 0;
                             }
                         }
 

--- a/Items/Helper.cs
+++ b/Items/Helper.cs
@@ -1,5 +1,5 @@
-﻿using Beatmap.Base;
-using Beatmap.V2;
+using Beatmap.Base;
+using Beatmap.Helper;
 using System.Collections.Generic;
 using System.Linq;
 using static Automapper.Items.Enumerator;
@@ -2105,14 +2105,14 @@ namespace Automapper.Items
                 {
                     if (found)
                     {
-                        BaseNote n = new V2Note
-                        {
-                            JsonTime = notes[i].JsonTime,
-                            PosX = notes[i].PosX,
-                            PosY = notes[i].PosY,
-                            Type = notes[i].Type,
-                            CutDirection = notes[i].CutDirection
-                        };
+                        BaseNote n = BeatmapFactory.Note(
+                            notes[i].JsonTime,
+                            notes[i].PosX,
+                            notes[i].PosY,
+                            notes[i].Type,
+                            notes[i].CutDirection,
+                            0
+                        );
                         pattern.Add(n);
                         notes.RemoveAt(i);
                         patterns.Add(new List<BaseNote>(pattern));
@@ -2130,14 +2130,14 @@ namespace Automapper.Items
                         pattern = new List<BaseNote>();
                         found = true;
                     }
-                    BaseNote n = new V2Note
-                    {
-                        JsonTime = notes[i].JsonTime,
-                        PosX = notes[i].PosX,
-                        PosY = notes[i].PosY,
-                        Type = notes[i].Type,
-                        CutDirection = notes[i].CutDirection
-                    };
+                    BaseNote n = BeatmapFactory.Note(
+                        notes[i].JsonTime,
+                        notes[i].PosX,
+                        notes[i].PosY,
+                        notes[i].Type,
+                        notes[i].CutDirection,
+                        0
+                    );
                     pattern.Add(n);
                     notes.RemoveAt(i);
                     i--;
@@ -2146,14 +2146,14 @@ namespace Automapper.Items
                 {
                     if (found)
                     {
-                        BaseNote n = new V2Note
-                        {
-                            JsonTime = notes[i].JsonTime,
-                            PosX = notes[i].PosX,
-                            PosY = notes[i].PosY,
-                            Type = notes[i].Type,
-                            CutDirection = notes[i].CutDirection
-                        };
+                        BaseNote n = BeatmapFactory.Note(
+                            notes[i].JsonTime,
+                            notes[i].PosX,
+                            notes[i].PosY,
+                            notes[i].Type,
+                            notes[i].CutDirection,
+                            0
+                        );
                         pattern.Add(n);
                         notes.RemoveAt(i);
                         i--;

--- a/Methods/Light.cs
+++ b/Methods/Light.cs
@@ -1,6 +1,6 @@
 ﻿using Automapper.Items;
 using Beatmap.Base;
-using Beatmap.V2;
+using Beatmap.Helper;
 using System.Collections.Generic;
 using System.Linq;
 using static Automapper.Items.Enumerator;
@@ -95,11 +95,11 @@ namespace Automapper.Methods
                 //Here we process Spin and Zoom
                 if (now == firstNote && time[1] == 0.0D) //If we are processing the first note, add spin + zoom + boost to it.
                 {
-                    eventTempo.Add(new V2Event(now, EventType.SPIN, 0));
-                    eventTempo.Add(new V2Event(now, EventType.ZOOM, 0));
+                    eventTempo.Add(BeatmapFactory.Event(now, EventType.SPIN, 0));
+                    eventTempo.Add(BeatmapFactory.Event(now, EventType.ZOOM, 0));
                     if (Options.UseBoostColor)
                     {
-                        eventTempo.Add(new V2Event(now, EventType.BOOST, 0));
+                        eventTempo.Add(BeatmapFactory.Event(now, EventType.BOOST, 0));
                         boost = false;
                     }
                 }
@@ -112,10 +112,10 @@ namespace Automapper.Methods
                         offset += Options.ColorSwap;
 
                         //Add a spin at timer.
-                        eventTempo.Add(new V2Event(offset, EventType.SPIN, 0));
+                        eventTempo.Add(BeatmapFactory.Event(now, EventType.SPIN, 0));
                         if (count == 0) //Only add zoom every 2 spin.
                         {
-                            eventTempo.Add(new V2Event(offset, EventType.ZOOM, 0));
+                            eventTempo.Add(BeatmapFactory.Event(now, EventType.ZOOM, 0));
                             count = 1;
                         }
                         else
@@ -127,7 +127,7 @@ namespace Automapper.Methods
                 //If there's a quarter between two float parallel notes and timer didn't pass the check.
                 else if (time[1] - time[2] == 0.25 && time[3] == time[2] && time[1] == now && timer < offset)
                 {
-                    eventTempo.Add(new V2Event(now, EventType.SPIN, 0));
+                    eventTempo.Add(BeatmapFactory.Event(now, EventType.SPIN, 0));
                 }
 
                 // Boost Event
@@ -141,12 +141,12 @@ namespace Automapper.Methods
 
                         if (boost)
                         {
-                            eventTempo.Add(new V2Event(boostIncrement, EventType.BOOST, 0));
+                            eventTempo.Add(BeatmapFactory.Event(boostIncrement, EventType.BOOST, 0));
                             boost = false;
                         }
                         else
                         {
-                            eventTempo.Add(new V2Event(boostIncrement, EventType.BOOST, 1));
+                            eventTempo.Add(BeatmapFactory.Event(boostIncrement, EventType.BOOST, 1));
                             boost = true;
                         }
                     }
@@ -185,20 +185,20 @@ namespace Automapper.Methods
                 {
                     if (now - last >= 1)
                     {
-                        eventTempo.Add(new V2Event((now - (now - last) / 2), EventType.BACK, 0));
-                        eventTempo.Add(new V2Event((now - (now - last) / 2), EventType.RING, 0));
-                        eventTempo.Add(new V2Event((now - (now - last) / 2), EventType.SIDE, 0));
-                        eventTempo.Add(new V2Event((now - (now - last) / 2), EventType.LEFT, 0));
-                        eventTempo.Add(new V2Event((now - (now - last) / 2), EventType.RIGHT, 0));
+                        eventTempo.Add(BeatmapFactory.Event(now - (now - last) / 2, EventType.BACK, 0));
+                        eventTempo.Add(BeatmapFactory.Event(now - (now - last) / 2, EventType.RING, 0));
+                        eventTempo.Add(BeatmapFactory.Event(now - (now - last) / 2, EventType.SIDE, 0));
+                        eventTempo.Add(BeatmapFactory.Event(now - (now - last) / 2, EventType.LEFT, 0));
+                        eventTempo.Add(BeatmapFactory.Event(now - (now - last) / 2, EventType.RIGHT, 0));
                     }
                     else
                     {
                         // Will be fused with some events, but we will sort that out later on.
-                        eventTempo.Add(new V2Event(now, EventType.BACK, 0));
-                        eventTempo.Add(new V2Event(now, EventType.RING, 0));
-                        eventTempo.Add(new V2Event(now, EventType.SIDE, 0));
-                        eventTempo.Add(new V2Event(now, EventType.LEFT, 0));
-                        eventTempo.Add(new V2Event(now, EventType.RIGHT, 0));
+                        eventTempo.Add(BeatmapFactory.Event(now, EventType.BACK, 0));
+                        eventTempo.Add(BeatmapFactory.Event(now, EventType.RING, 0));
+                        eventTempo.Add(BeatmapFactory.Event(now, EventType.SIDE, 0));
+                        eventTempo.Add(BeatmapFactory.Event(now, EventType.LEFT, 0));
+                        eventTempo.Add(BeatmapFactory.Event(now, EventType.RIGHT, 0));
                     }
 
                     doubleOn = false;
@@ -208,11 +208,11 @@ namespace Automapper.Methods
                 if ((now == time[1] || (now - time[1] <= 0.02 && time[1] != time[2])) && (time[1] != 0.0D && now != last) && !sliderTiming.Exists(e => e.JsonTime == now))
                 {
                     int color = FindColor(Notes.First().JsonTime, time[0]);
-                    eventTempo.Add(new V2Event(now, EventType.BACK, color)); //Back Top Laser
-                    eventTempo.Add(new V2Event(now, EventType.RING, color)); //Track Ring Neons
-                    eventTempo.Add(new V2Event(now, EventType.SIDE, color)); //Side Light
-                    eventTempo.Add(new V2Event(now, EventType.LEFT, color)); //Left Laser
-                    eventTempo.Add(new V2Event(now, EventType.RIGHT, color)); //Right Laser
+                    eventTempo.Add(BeatmapFactory.Event(now, EventType.BACK, color)); //Back Top Laser
+                    eventTempo.Add(BeatmapFactory.Event(now, EventType.RING, color)); //Track Ring Neons
+                    eventTempo.Add(BeatmapFactory.Event(now, EventType.SIDE, color)); //Side Light
+                    eventTempo.Add(BeatmapFactory.Event(now, EventType.LEFT, color)); //Left Laser
+                    eventTempo.Add(BeatmapFactory.Event(now, EventType.RIGHT, color)); //Right Laser
 
                     // Laser speed based on rhythm
                     if (time[0] - time[1] < 0.25)
@@ -232,8 +232,8 @@ namespace Automapper.Methods
                         currentSpeed = 1;
                     }
 
-                    eventTempo.Add(new V2Event(now, EventType.LEFT_ROT, currentSpeed)); //Left Rotation
-                    eventTempo.Add(new V2Event(now, EventType.RIGHT_ROT, currentSpeed)); //Right Rotation
+                    eventTempo.Add(BeatmapFactory.Event(now, EventType.LEFT_ROT, currentSpeed)); //Left Rotation
+                    eventTempo.Add(BeatmapFactory.Event(now, EventType.RIGHT_ROT, currentSpeed)); //Right Rotation
 
                     doubleOn = true;
                     last = now;
@@ -386,19 +386,19 @@ namespace Automapper.Methods
 
                     // Place light
                     int color = FindColor(Notes.First().JsonTime, time[0]);
-                    eventTempo.Add(new V2Event(time[0], sliderLight[sliderIndex], color - 2));
-                    eventTempo.Add(new V2Event(time[0] + 0.125f, sliderLight[sliderIndex], color - 1));
-                    eventTempo.Add(new V2Event(time[0] + 0.25f, sliderLight[sliderIndex], color - 2));
-                    eventTempo.Add(new V2Event(time[0] + 0.375f, sliderLight[sliderIndex], color - 1));
-                    eventTempo.Add(new V2Event(time[0] + 0.5f, sliderLight[sliderIndex], 0));
+                    eventTempo.Add(BeatmapFactory.Event(time[0], sliderLight[sliderIndex], color - 2));
+                    eventTempo.Add(BeatmapFactory.Event(time[0] + 0.125f, sliderLight[sliderIndex], color - 1));
+                    eventTempo.Add(BeatmapFactory.Event(time[0] + 0.25f, sliderLight[sliderIndex], color - 2));
+                    eventTempo.Add(BeatmapFactory.Event(time[0] + 0.375f, sliderLight[sliderIndex], color - 1));
+                    eventTempo.Add(BeatmapFactory.Event(time[0] + 0.5f, sliderLight[sliderIndex], 0));
 
                     sliderIndex--;
 
                     // Spin goes brrr
-                    eventTempo.Add(new V2Event(time[0], EventType.SPIN, 0));
+                    eventTempo.Add(BeatmapFactory.Event(time[0], EventType.SPIN, 0));
                     for (int i = 0; i < 8; i++)
                     {
-                        eventTempo.Add(new V2Event(time[0] + 0.5f - (0.5f / 8f * i), EventType.SPIN, 0));
+                        eventTempo.Add(BeatmapFactory.Event(time[0] + 0.5f - (0.5f / 8f * i), EventType.SPIN, 0));
                     }
 
                     wasSlider = true;
@@ -428,7 +428,7 @@ namespace Automapper.Methods
                     }
 
                     // Place the next light
-                    eventTempo.Add(new V2Event(time[0], pattern[patternIndex], FindColor(Notes.First().JsonTime, time[0])));
+                    eventTempo.Add(BeatmapFactory.Event(time[0], pattern[patternIndex], FindColor(Notes.First().JsonTime, time[0])));
 
                     // Speed based on rhythm
                     if (time[0] - time[1] < 0.25)
@@ -451,11 +451,11 @@ namespace Automapper.Methods
                     // Add laser rotation if necessary
                     if (pattern[patternIndex] == 2)
                     {
-                        eventTempo.Add(new V2Event(time[0], EventType.LEFT_ROT, currentSpeed));
+                        eventTempo.Add(BeatmapFactory.Event(time[0], EventType.LEFT_ROT, currentSpeed));
                     }
                     else if (pattern[patternIndex] == 3)
                     {
-                        eventTempo.Add(new V2Event(time[0], EventType.RIGHT_ROT, currentSpeed));
+                        eventTempo.Add(BeatmapFactory.Event(time[0], EventType.RIGHT_ROT, currentSpeed));
                     }
 
                     // Place off event
@@ -466,12 +466,12 @@ namespace Automapper.Methods
                             if (Selection[Selection.FindIndex(n => n == note) + 1].JsonTime - time[0] <= 2)
                             {
                                 float value = (Selection[Selection.FindIndex(n => n == note) + 1].JsonTime - Selection[Selection.FindIndex(n => n == note)].JsonTime) / 2;
-                                eventTempo.Add(new V2Event(Selection[Selection.FindIndex(n => n == note)].JsonTime + value, pattern[patternIndex], 0));
+                                eventTempo.Add(BeatmapFactory.Event(Selection[Selection.FindIndex(n => n == note)].JsonTime + value, pattern[patternIndex], 0));
                             }
                         }
                         else
                         {
-                            eventTempo.Add(new V2Event(Selection[Selection.FindIndex(n => n == note) + 1].JsonTime, pattern[patternIndex], 0));
+                            eventTempo.Add(BeatmapFactory.Event(Selection[Selection.FindIndex(n => n == note) + 1].JsonTime, pattern[patternIndex], 0));
                         }
                     }
 

--- a/Methods/NoteGenerator.cs
+++ b/Methods/NoteGenerator.cs
@@ -1,6 +1,6 @@
 ﻿using Automapper.Items;
 using Beatmap.Base;
-using Beatmap.V2;
+using Beatmap.Helper;
 using System.Collections.Generic;
 using static Automapper.Items.Enumerator;
 using static Automapper.Items.Helper;
@@ -100,7 +100,7 @@ namespace Automapper.Methods
 
                     if (notes.Count == 0 && lastBlue == null)
                     {
-                        BaseNote n = new V2Note(timing, 2, 0, 1, 1);
+                        BaseNote n = BeatmapFactory.Note(timing, 2, 0, 1, 1, 0);
                         notes.Add(n);
                         lastRight = timing;
                         rightSwing = 1;
@@ -108,7 +108,7 @@ namespace Automapper.Methods
                     }
                     else if (notes.Count == 1 && lastRed == null)
                     {
-                        BaseNote n = new V2Note(timing, 1, 0, 0, 1);
+                        BaseNote n = BeatmapFactory.Note(timing, 1, 0, 0, 1, 0);
                         notes.Add(n);
                         lastLeft = timing;
                         leftSwing = 1;
@@ -168,13 +168,13 @@ namespace Automapper.Methods
                     // Create the note and add it to the list
                     if (hand == 1)
                     {
-                        BaseNote note = new V2Note(timing, 2, 0, hand, direction);
+                        BaseNote note = BeatmapFactory.Note(timing, 2, 0, hand, direction, 0);
                         notes.Add(note);
                         hand = 0; // Switch hand for the next note
                     }
                     else
                     {
-                        BaseNote note = new V2Note(timing, 1, 0, hand, direction);
+                        BaseNote note = BeatmapFactory.Note(timing, 1, 0, hand, direction, 0);
                         notes.Add(note);
                         hand = 1; // Switch hand for the next note
                     }
@@ -258,11 +258,11 @@ namespace Automapper.Methods
 
                     if (notes.Exists(o => o.JsonTime == t))
                     {
-                        beatmapNote = new V2Note(t, 1, 0, 1, 8);
+                        beatmapNote = BeatmapFactory.Note(t, 1, 0, 1, 8, 0);
                     }
                     else
                     {
-                        beatmapNote = new V2Note(t, 0, 0, 0, 8);
+                        beatmapNote = BeatmapFactory.Note(t, 0, 0, 0, 8, 0);
                     }
 
                     notes.Add(beatmapNote);


### PR DESCRIPTION
This generates v2 objects on v2 maps and v3 objects on v3 maps instead of generating v2 objects and converting it on save.
  * Avoids a possible null ref